### PR TITLE
rubocop 0.77.0

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -88,16 +88,16 @@ Layout/ExtraSpacing:
 # Layout/FirstMethodArgumentLineBreak
 # Layout/FirstMethodParameterLineBreak
 
-Layout/IndentFirstArgument:
+Layout/FirstArgumentIndentation:
   Enabled: false
 
-Layout/IndentFirstArrayElement:
+Layout/FirstArrayElementIndentation:
   Enabled: false
 
 Layout/AssignmentIndentation:
   Enabled: false
 
-Layout/IndentFirstHashElement:
+Layout/FirstHashElementIndentation:
   Enabled: false
 
 # Layout/IndentHeredoc

--- a/rubocop.yml
+++ b/rubocop.yml
@@ -1,10 +1,10 @@
 Layout/AccessModifierIndentation:
   Enabled: false
 
-Layout/AlignArray:
+Layout/ArrayAlignment:
   Enabled: false
 
-Layout/AlignHash:
+Layout/HashAlignment:
   Enabled: false
 
 # Layout/AlignParameters
@@ -94,7 +94,7 @@ Layout/IndentFirstArgument:
 Layout/IndentFirstArrayElement:
   Enabled: false
 
-Layout/IndentAssignment:
+Layout/AssignmentIndentation:
   Enabled: false
 
 Layout/IndentFirstHashElement:
@@ -211,7 +211,7 @@ Layout/SpaceInsideStringInterpolation:
 Layout/Tab:
   Enabled: false
 
-Layout/TrailingBlankLines:
+Layout/TrailingEmptyLines:
   Enabled: false
 
 Layout/TrailingWhitespace:


### PR DESCRIPTION
resolve obsolete configuration:
```
Error: The `Layout/AlignArray` cop has been renamed to `Layout/ArrayAlignment`.
(obsolete configuration found in 
The `Layout/AlignHash` cop has been renamed to `Layout/HashAlignment`.
(obsolete configuration found in 
The `Layout/IndentArray` cop has been renamed to `Layout/FirstArrayElementIndentation`.
(obsolete configuration found in 
The `Layout/IndentAssignment` cop has been renamed to `Layout/AssignmentIndentation`.
(obsolete configuration found in 
The `Layout/IndentHash` cop has been renamed to `Layout/FirstHashElementIndentation`.
(obsolete configuration found in 
The `Layout/TrailingBlankLines` cop has been renamed to `Layout/TrailingEmptyLines`.
(obsolete configuration found in 
```